### PR TITLE
temp fix for horizontal scrollbar

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -27,3 +27,7 @@
 html[data-theme='dark'] .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.3);
 }
+
+body {
+  overflow-x: hidden !important;
+}


### PR DESCRIPTION
to get the full-width purple background to work on the main page (from "within" docusaurus content) ends up causing a horizontal scroll -- for this interim release adding an overflow-x: hidden to hide